### PR TITLE
Docker setup skripti

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     container_name: kierratysavustin_db
 
   kierratysavustin_client:
-    image: kierratysavustin/kierratysavustin:staging
+    image: kierratysavustin-local
     restart: unless-stopped
     container_name: kierratysavustin_client
 

--- a/docker-setup.sh
+++ b/docker-setup.sh
@@ -1,0 +1,9 @@
+docker build --build-arg PUBLIC_URL=/kierratysavustin -t kierratysavustin-local .
+docker-compose up -d
+echo ""
+echo ""
+echo "Sovellus pyörii osoitteessa http://localhost:3001/kierratysavustin"
+echo "Sammuta sovellus painamalla Enter"
+read -p ""
+echo ""
+docker-compose down


### PR DESCRIPTION
Pieni setupskripti, jonka avulla saa sovelluksen pyörimään lokaalissa Dockerissa staging serveriä vastaavassa ympäristössä. Käytännössä siis jos on dockeri asennettuna, niin riittää, että ajaa projektin kansiossa olevan skriptin ./docker-setup.sh (toimii käytännössä vain Linux ympäristössä).