### PR TITLE
mongo-express

### DIFF
--- a/mongo/docker-compose.yml
+++ b/mongo/docker-compose.yml
@@ -3,8 +3,18 @@ version: '3.7'
 services:
   mongo:
     image: mongo:bionic
+    restart: unless-stopped
     volumes:
       - ./data:/data/db
-    restart: unless-stopped
     ports:
       - 27017:27017
+    container_name: mongo
+
+  mongo-express:
+    image: mongo-express:latest
+    restart: unless-stopped
+    depends_on: 
+      - mongo
+    ports:
+      - 8081:8081
+    container_name: mongo-express

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,8 @@
     "start": "NODE_ENV=development node index.js",
     "test": "echo \"Error: no test specified\" && exit 1",
     "start:prod": "NODE_ENV=production node index.js",
-    "start:test": "NODE_ENV=test node index.js"
+    "start:test": "NODE_ENV=test node index.js",
+    "start:mongo": "cd ../mongo && docker-compose up && cd ../mongo && docker-compose down"
   },
   "author": "KA",
   "license": "MIT",


### PR DESCRIPTION
Lisäsin devausaikaiseen mongon docker-composeen mongo-expressin. Kun expressin käynnistää konsoliin tulee viesti 

> Mongo Express server listening at http://0.0.0.0:8081
> Server is open to allow connections from anyone (0.0.0.0)
> basicAuth credentials are "admin:pass", it is recommended you change this in your config.js!

En tiedä onko toi minkälainen tietoturvariski. En osannut äkkiseltään korjata tota. Luulisin ettei devausaikana ole ongelma, mutta jos joku tietää paremmin niin sanokaa, niin käytän ton korjaamiseen enemmän aikaa tai poistan sen kokonaan. 

Mongo-express on siis graafinen admin työkalu mongo tietokannalle. Sillä voi tarkastella tietokannan sisältöä, poistaa sieltä kokoelmia ja yksittäisiä tietoja ynnä muuta. Kun mongon ja expressin käynnistää express käynnistyy localhost:8081.

Lisäsin myös backendiin npm scriptin, jolla saa mongon ja expressin käynnistettyä. Kun server kansiossa kirjoittaa _npm run start:mongo_ scripti tekee kansiossa mongo docker-compose up, ja kun samassa konsolissa sitten lopetettuaan painaa control C, mongo ja express lopetetaan ja scripti tekee mongo kansiossa docker-compose down. Näin toivottavasti mongon käyttäminen lokaalisti helpottuu, eikä komentoa docker-compose down tarvitse itse muistaa kirjoittaa.