### PR TITLE
SearchFormin jest testien korjaus

### DIFF
--- a/client/src/tests/SearchForm.test.js
+++ b/client/src/tests/SearchForm.test.js
@@ -1,58 +1,80 @@
 import React from 'react'
 import '@testing-library/jest-dom/extend-expect'
+import {
+  Switch, Route
+} from 'react-router-dom'
 import { render, fireEvent } from '@testing-library/react'
 import SearchForm from '../components/SearchForm'
+import ProductList from '../components/ProductList'
 import {
   BrowserRouter as Router
 } from 'react-router-dom'
 
 
 test('Search form renders and returns correct results', () => {
-
-  const products = [{
+  const productA = {
     id: '1',
     name: 'Mustamakkarakastike pullo',
     instructions: [{
       id: 'tuote1',
       instruction: 'Irrota korkki, huuhtele pullo. Laita pullo ja korkki muovinkeräykseen erillään toisistaan.'
     }]
-  }]
+  }
+
+  const productB = {
+    id: '2',
+    name: 'Sanomalehti',
+    instructions: [{
+      id: 'tuote2',
+      instruction: 'Laita lehti paperinkeräykseen'
+    }]
+  }
+
+  const productC = {
+    id: '3',
+    name: 'Aikakauslehti',
+    instructions: [{
+      id: 'tuote3',
+      instruction: 'Laita aikauslehti paperinkeräykseen'
+    }]
+  }
+
+  const productsData = [
+    productA,
+    productB,
+    productC
+  ]
+
+  const changeFoundProducts = jest.fn()
 
   const component = render(
     <Router>
-      <SearchForm products={products} setFoundProducts={null} />
+      <Switch>
+        <Route path="/searchResults">
+          <ProductList products={[]} />
+        </Route>
+        <Route path="/">
+          <SearchForm products={productsData} setFoundProducts={changeFoundProducts} />
+        </Route>
+      </Switch>
     </Router>
 
   )
-
 
   expect(component.container).toHaveTextContent(
     'Hakusana'
   )
 
-  expect(component.container).not.toHaveTextContent(
-    'Mustamakkarakastike pullo'
-  )
-
-  //const input = component.container.querySelector('input')
-  //const form = component.container.querySelector('form')
-
-  /* fireEvent.change(input, {
-    target: { value: 'pullo' }
-  })
-  fireEvent.submit(form) */
-
-  /* expect(component.container).toHaveTextContent(
-    'Mustamakkarakastike pullo'
-  )
+  const input = component.container.querySelector('input')
+  const form = component.container.querySelector('form')
 
   fireEvent.change(input, {
-    target: { value: 'abcdefg' }
+    target: { value: 'lehti' }
   })
   fireEvent.submit(form)
 
-  expect(component.container).not.toHaveTextContent(
-    'Mustamakkarakastike pullo'
-  ) */
+  expect(changeFoundProducts.mock.calls).toHaveLength(1)
+  expect(changeFoundProducts.mock.calls[0][0][0]).toBe(productB)
+
 
 })


### PR DESCRIPTION
Search form testejä säädetty siten, että nyt testataan selkeämmin vain SearchForm komponenttia ja testit toimii uudella SearchForm toteutuksella. Testit saa ajettua siis clientin kansiossa komennolla `CI=true npm test` 

Huomasin samalla, että Formikin käyttöönotto on hajottanut loginformin Jest testit, eli ne feilaa tällä hetkellä. Jos haluaa ajaa vain SearchForm testit, se onnistuu komennolla `CI=true npm test -- src/tests/SearchForm.test.js` 