### PR TITLE
Lisää jest testejä

### DIFF
--- a/client/src/tests/InstructionForm.test.js
+++ b/client/src/tests/InstructionForm.test.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render } from '@testing-library/react'
+import InstructionForm from '../components/InstructionForm'
+
+test('InstructionForm renders', () => {
+
+  const component = render(
+    <InstructionForm />
+  )
+
+  expect(component.container).toHaveTextContent(
+    'Kierrätys ohje:'
+  )
+
+})

--- a/client/src/tests/Product.test.js
+++ b/client/src/tests/Product.test.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render } from '@testing-library/react'
+import Product from '../components/Product'
+/* import {
+  BrowserRouter as Router
+} from 'react-router-dom'
+ */
+
+test('Product information can be seen', () => {
+  const productA = {
+    id: '1',
+    name: 'Mustamakkarakastike pullo',
+    instructions: [{
+      id: 'tuote1',
+      information: 'Irrota korkki, huuhtele pullo. Laita pullo ja korkki muovinkeräykseen erillään toisistaan.'
+    }]
+  }
+
+  const component = render(
+    <Product product={productA} />
+  )
+
+  expect(component.container).toHaveTextContent(
+    'Mustamakkarakastike pullo'
+  )
+
+  expect(component.container).toHaveTextContent(
+    'Irrota korkki, huuhtele pullo. Laita pullo ja korkki muovinkeräykseen erillään toisistaan.'
+  )
+})

--- a/client/src/tests/ProductList.test.js
+++ b/client/src/tests/ProductList.test.js
@@ -1,0 +1,80 @@
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render } from '@testing-library/react'
+import ProductList from '../components/ProductList'
+import {
+  BrowserRouter as Router
+} from 'react-router-dom'
+
+
+test('ProductList list products', () => {
+  const productA = {
+    id: '1',
+    name: 'Mustamakkarakastike pullo',
+    instructions: [{
+      id: 'tuote1',
+      instruction: 'Irrota korkki, huuhtele pullo. Laita pullo ja korkki muovinkeräykseen erillään toisistaan.'
+    }]
+  }
+
+  const productB = {
+    id: '2',
+    name: 'Sanomalehti',
+    instructions: [{
+      id: 'tuote2',
+      instruction: 'Laita lehti paperinkeräykseen'
+    }]
+  }
+
+  const productC = {
+    id: '3',
+    name: 'Aikakauslehti',
+    instructions: [{
+      id: 'tuote3',
+      instruction: 'Laita aikauslehti paperinkeräykseen'
+    }]
+  }
+
+  const productsData = [
+    productA,
+    productB,
+    productC
+  ]
+
+
+  const component = render(
+    <Router>
+      <ProductList products={productsData} />
+    </Router>
+  )
+
+  expect(component.container).toHaveTextContent(
+    'Mustamakkarakastike pullo'
+  )
+
+  expect(component.container).toHaveTextContent(
+    'Sanomalehti'
+  )
+
+  expect(component.container).toHaveTextContent(
+    'Aikakauslehti'
+  )
+
+})
+
+test('ProductList shows message when list is empty', () => {
+
+  const productsData = []
+
+
+  const component = render(
+    <Router>
+      <ProductList products={productsData} />
+    </Router>
+  )
+
+  expect(component.container).toHaveTextContent(
+    'Haulla ei löytynyt yhtään tuotetta!'
+  )
+
+})


### PR DESCRIPTION
Lisäsin jest testausta komponenteille Product, ProductList ja alustava testi InstructionFormilla. InstructionFormia oli kai tarkoitus säätää lähiaikoina, niin en sille tehnyt mitään muuta kuin renredöitymisen testauksen.

Tässä yhteydessä pohdin, että pitäisköhän refaktoroida koodia siten, että nuo tietokantaan lisäävät funktiot annetaan komponenteille propseina, jolloin ne olisi helppo korvata mock versioilla testeissä, eli samaan tyyliin kuin näissä esimerkeissä: [https://fullstackopen.com/osa5/react_sovellusten_testaaminen#lomakkeiden-testaus](https://fullstackopen.com/osa5/react_sovellusten_testaaminen#lomakkeiden-testaus)
