### PR TITLE
cypress testailua

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -32,7 +32,7 @@ const App = () => {
       <div>
         <Link style={padding} to="/">etusivu</Link>
         <Link id='productForm' style={padding} to="/new">lisää tuote</Link>
-        <Link style={padding} to="/products">tuotteet</Link>
+        <Link id='productList' style={padding} to="/products">tuotteet</Link>
         <Link style={padding} to="/register">rekisteröidy</Link>
       </div>
 

--- a/client/src/components/InstructionForm.js
+++ b/client/src/components/InstructionForm.js
@@ -12,7 +12,7 @@ const InstructionForm = ({ id }) => {
     <div>
       <form onSubmit={handleSubmit}>
         <label>
-            Kierrätys ohje:
+            Kierrätysohje:
           <input id="instructionInput"
             type='text'
             value={information}

--- a/client/src/components/Product.js
+++ b/client/src/components/Product.js
@@ -11,7 +11,7 @@ const Product = ({ product }) => {
       {product.instructions.map(info =>
         <li id ="productInstruction" key={info.id}>{info.information}</li>
       )}
-      <h2>Lisää tuotteelle kierrätys ohje</h2>
+      <h2>Lisää tuotteelle kierrätysohje</h2>
 
       <InstructionForm id = {product.id}/>
     </div>

--- a/client/src/components/ProductForm.js
+++ b/client/src/components/ProductForm.js
@@ -3,18 +3,13 @@ import productService from '../services/products'
 
 const ProductForm = ({ products, setProducts }) => {
   const [productName, setProductName] = useState('')
-  const [description, setDescription] = useState('')
-  //const [products, setProducts] = useState([])
   const handleSubmit = (event) => {
     event.preventDefault()
-    const product = { productName, description }
+    const product = { productName }
     productService.create(product).then(returnedProduct => {
       setProducts(products.concat(returnedProduct))
     })
-    //setProducts(p => p.concat(products))
-    console.log(setProducts)
     setProductName('')
-    setDescription('')
   }
   return (
     <div>
@@ -25,15 +20,6 @@ const ProductForm = ({ products, setProducts }) => {
             type='text'
             value={productName}
             onChange={({ target }) => setProductName(target.value)}
-          />
-        </label>
-        <br />
-        <label>
-          Tuotteen selitys
-          <input id="descriptionInput"
-            type='text'
-            value={description}
-            onChange={({ target }) => setDescription(target.value)}
           />
         </label>
         <br />

--- a/client/src/components/RegisterForm.js
+++ b/client/src/components/RegisterForm.js
@@ -68,7 +68,7 @@ const RegisterForm = () => {
                 className={!(dirty && isValid) ? 'disabled-btn' : ''}
                 disabled={!(dirty && isValid)}
               >
-              Sign In
+              Rekisteröidy
               </button>
             </Form>
           </div>

--- a/client/src/services/products.js
+++ b/client/src/services/products.js
@@ -3,7 +3,6 @@ import axios from 'axios'
 const baseUrl = `${process.env.PUBLIC_URL}/api/products`
 
 const create = async newObject => {
-  console.log('objecti', newObject)
   const response = axios.post(baseUrl, newObject)
   return response.then(response => response.data)
 }

--- a/e2e_tests/cypress/integration/recycling-app.spec.js
+++ b/e2e_tests/cypress/integration/recycling-app.spec.js
@@ -1,30 +1,65 @@
-describe('Recycling app', function() {
-  it('productlist page can be opened', function() {
+describe('Recycling app', () => {
+  beforeEach(() => {
+    cy.request('POST', 'api/tests/reset')
     cy.visit('/')
+  })
+
+  it('productlist page can be opened', () => {
     cy.contains('Kotitalouden kierrätysavustin')
   })
-  it('Product can be added to application', function() {
-    cy.visit('/')
+
+  it('Product can be added to application', () => {
     cy.get('#productForm').click()
     cy.get('#nameInput').type('Muovipussi')
-    cy.get('#descriptionInput').type('Muovia')
     cy.get('#addproductBtn').click()
   })
-  it('search returns products', function() {
-    cy.visit('/')
-    cy.reload()
-    cy.get('#searchInput').type('pussi')
-    cy.get('#searchBtn').click()
-    cy.contains('Muovipussi')
-  })
-  it('product can be clicked and instruction can be added', function(){
-    //cy.visit('/')
-    //cy.contains('Haulla ei löytynyt yhtään tuotetta!')
-    cy.contains('Muovipussi').click()
-    cy.get('#instructionInput').type('Tuotteen voi uudelleen käyttää roskapussina')
-    cy.get('#addInstruction').click()
-    cy.reload() // Reloadin voi poistaa kun otetaan taulukko käyttöön tietojen tallentamiseen
- 
-    cy.contains('Tuotteen voi uudelleen käyttää roskapussina')
+
+  describe('when a product is added', () => {
+    beforeEach(() => {
+      cy.get('#productForm').click()
+      cy.get('#nameInput').type('Muovipussi')
+      cy.get('#addproductBtn').click()
+      cy.visit('/')
+    })
+
+    it('search returns the added product if the search term matches it', () => {
+      cy.get('#searchInput').type('pussi')
+      cy.get('#searchBtn').click()
+      cy.contains('Muovipussi')
+      cy.contains('Haulla ei löytynyt yhtään tuotetta!').should('not.exist')
+    })
+
+    it('search informs user if no items matches the search term', () => {
+      cy.get('#searchInput').type('zqxwce')
+      cy.get('#searchBtn').click()
+      cy.contains('Haulla ei löytynyt yhtään tuotetta!')
+      cy.contains('Muovipussi').should('not.exist')
+    })
+
+    describe('and the product is searched', () => {
+      beforeEach(() => {
+        cy.get('#searchInput').type('pussi')
+        cy.get('#searchBtn').click()
+      })
+
+      it('its product information can be opened and seen', () => {
+        cy.contains('Muovipussi').click()
+        cy.contains('Lisää tuotteelle kierrätys ohje')
+      })
+
+      describe('and the product information is opened', () => {
+        beforeEach(() => {
+          cy.contains('Muovipussi').click()
+        })
+
+        it('recycling information can be added to it', () => {
+          cy.get('#instructionInput').type('Tuotteen voi uudelleen käyttää roskapussina')
+          cy.get('#addInstruction').click()
+          cy.reload() // Reloadin voi poistaa kun otetaan taulukko käyttöön tietojen tallentamiseen
+
+          cy.contains('Tuotteen voi uudelleen käyttää roskapussina')
+        })
+      })
+    })
   })
 })

--- a/e2e_tests/cypress/integration/recycling-app.spec.js
+++ b/e2e_tests/cypress/integration/recycling-app.spec.js
@@ -12,6 +12,8 @@ describe('Recycling app', () => {
     cy.get('#productForm').click()
     cy.get('#nameInput').type('Muovipussi')
     cy.get('#addproductBtn').click()
+    cy.get('#productList').click()
+    cy.contains('Muovipussi')
   })
 
   describe('when a product is added', () => {
@@ -44,7 +46,7 @@ describe('Recycling app', () => {
 
       it('its product information can be opened and seen', () => {
         cy.contains('Muovipussi').click()
-        cy.contains('Lisää tuotteelle kierrätys ohje')
+        cy.contains('Lisää tuotteelle kierrätysohje')
       })
 
       describe('and the product information is opened', () => {

--- a/server/controllers/products.js
+++ b/server/controllers/products.js
@@ -2,14 +2,10 @@ const productRouter = require("express").Router()
 const Product = require('../models/product')
 const Instruction = require('../models/instruction')
 
-productRouter.post('/', async(req,res) => {
-    
+productRouter.post('/', async(req,res) => {  
     const body = req.body
-    console.log("body",body)
-   
         const product = new Product({
         name: body.productName,
-        description: body.description
     })
     const result = await product.save()
 
@@ -22,7 +18,6 @@ productRouter.post('/:id/instructions', async(req,res) => {
     if(!product){
         return res.status(401).json({ error: "No product" });
     }
-    
     const instruction = new Instruction(req.body)
     instruction.product = product.id
     const result = await instruction.save()

--- a/server/controllers/tests.js
+++ b/server/controllers/tests.js
@@ -1,0 +1,14 @@
+const testRouter = require('express').Router()
+const Product = require('../models/product')
+const Instruction = require('../models/instruction')
+const User = require('../models/user')
+
+testRouter.post('/reset', async (req, res) => {
+    await Product.deleteMany({})
+    await Instruction.deleteMany({})
+    await User.deleteMany({})
+
+    res.status(204).end()
+})
+
+module.exports = testRouter

--- a/server/index.js
+++ b/server/index.js
@@ -11,16 +11,20 @@ app.use(express.json());
 app.use('/api/products', productRouter);
 app.use('/api/users', userRouter)
 
-if (process.env.NODE_ENV !== 'development') {
-  app.use(express.static('build'))
-  app.get("*", (req, res) => res.sendFile(path.resolve("build", "index.html")))
+if (process.env.NODE_ENV === 'test') {
+  const testRouter = require('./controllers/tests')
+  app.use('/api/tests', testRouter)
 }
 
-const http = require('http')
+app.use(express.static('build'))
+app.get("*", (req, res) => res.sendFile(path.resolve("build", "index.html")))
+
+const http = require('http');
+const { EPIPE } = require("constants");
 const server = http.createServer(app)
 
 console.log('>>>>> connecting to <<<<<', config.MONGODB_URI)
-mongoose.connect(config.MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true } )
+mongoose.connect(config.MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology: true })
   .then(() => {
     console.log('>>>>> connected to MongoDB <<<<<')
   })
@@ -28,6 +32,6 @@ mongoose.connect(config.MONGODB_URI, { useNewUrlParser: true, useUnifiedTopology
     console.log('>>>>> error connection to MongoDB: <<<<<', error.message)
   })
 
- server.listen(config.PORT, () => {
-   console.log(`Server running on port ${config.PORT}`)
- })
+server.listen(config.PORT, () => {
+  console.log(`Server running on port ${config.PORT}`)
+})

--- a/server/index.js
+++ b/server/index.js
@@ -1,9 +1,9 @@
 const config = require("./utils/config");
 const express = require("express");
-const app = express();
-const mongoose = require("mongoose");
+const app = express()
+const mongoose = require("mongoose")
 const cors = require('cors')
-const productRouter = require("./controllers/products");
+const productRouter = require("./controllers/products")
 const userRouter = require("./controllers/users")
 const path = require('path')
 app.use(cors())
@@ -19,8 +19,7 @@ if (process.env.NODE_ENV === 'test') {
 app.use(express.static('build'))
 app.get("*", (req, res) => res.sendFile(path.resolve("build", "index.html")))
 
-const http = require('http');
-const { EPIPE } = require("constants");
+const http = require('http')
 const server = http.createServer(app)
 
 console.log('>>>>> connecting to <<<<<', config.MONGODB_URI)

--- a/server/models/product.js
+++ b/server/models/product.js
@@ -2,7 +2,6 @@ const mongoose = require("mongoose")
 
 const productSchema = new mongoose.Schema({
     name: {type: String, required: true},
-    description: {type:String, required:true},
     instructions: [
         {
             type: mongoose.Schema.Types.ObjectId,

--- a/server/utils/config.js
+++ b/server/utils/config.js
@@ -2,6 +2,10 @@ let PORT = process.env.PORT || 3001
 
 let MONGODB_URI = 'mongodb://localhost:27017/dev_db'
 
+if (process.env.NODE_ENV === 'test') {
+  MONGODB_URI = 'mongodb://localhost:27017/test_db'
+}
+
 if (process.env.NODE_ENV === 'production') {
   MONGODB_URI = 'mongodb://kierratysavustin_db:27017/prod_db'
 }


### PR DESCRIPTION
Muokkasin sovelluksen käyttämään erillistä testitietokantaa, kun server käynnistetään komennolla npm run start:test. Cypress tyhjentää tietokannan testien alussa. Tätä varten tein backendiin testirouterin joka otetaan käyttöön kun server kännistetään testaus tilassa. Poistin sovelluksesta tuotteen 'selitys'-kentän ja muokkasin cypress testejä vastaamaan jokseenkin full stack materiaalissa käytettyä tyyliä (https://github.com/FullStack-HY/part2-notes/blob/part5-9/cypress/integration/note_app.spec.js#L34).