### PR TITLE
Lisätty mongo startup skripti

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,7 @@
     "test": "jest --verbose",
     "start:prod": "NODE_ENV=production node index.js",
     "start:test": "NODE_ENV=test node index.js",
-    "start:mongo": "cd ../mongo && docker-compose up && cd ../mongo && docker-compose down"
+    "start:mongo": "cd .. && ./start-mongo-docker.sh"
   },
   "author": "KA",
   "license": "MIT",

--- a/start-mongo-docker.sh
+++ b/start-mongo-docker.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+cd mongo
+
+echo "Käynnistetään dockerissa mongo ja mongo-express"
+# Mongon tulostukset näkyy konsolissa ja
+# jäädään odottamaan sammuttamista (Ctrl-C),
+docker-compose up
+
+echo ""
+echo "Poistetaan mongo ja mongo-express"
+# Tämä komento ajetan vasta Ctrl-C jälken
+docker-compose down
+
+echo ""
+echo ""
+echo "mongo ja mongo-express sammutettu ja poistettu!"
+
+# Ctrl-C pitäisi toimia tässä tapauksessa näin, mutta
+# joissain tapauksissa Ctrl-C saattaa pysäyttää tämän koko
+# skriptin toimnnan. Oikean lopputuloksen näkee siitä, että
+# lopuksi tulostuu:
+#
+# Stopping mongo-express ... done
+# Stopping mongo         ... done
+#
+# Poistetaan mongo ja mongo-express
+# Removing mongo-express ... done
+# Removing mongo         ... done
+# Removing network mongo_default
+#
+#
+# mongo ja mongo-express sammutettu ja poistettu!
+#
+# Jos näkyy pelkkästään
+#
+# Stopping mongo-express ... done
+# Stopping mongo         ... done
+#
+# Jää verkkoyhteydet yms. edelleen käyntiin ja tulee ajaa erikseen
+# mongo kansiossa komento: docker-compose down


### PR DESCRIPTION
Tein mongon käynnistämisen ja sammuttamisen hoitavan skriptin ja lisäsin sen serverin npm skripteihin, toimii siis sillä samalla `npm run start:mongo`

Toimii ainakin omalla ubuntu koneella nyt niinkuin pitää, mutta toiminta pitää vielä varmistaa macissä.

Mongon tulostukset näkyy konsolissa ja jäädään odottamaan sammuttamista (Ctrl-C). Ainakin itellä toimii juuri niinkuin pitäisi, mutta tiedän, että joissan muissa skripteissä Ctrl-C pysäyttää koko skriptin toimnnan siihen paikkaan. Oikean lopputuloksen näkee siitä, että lopuksi tulostuu:

```
Stopping mongo-express ... done
Stopping mongo         ... done

Poistetaan mongo ja mongo-express
Removing mongo-express ... done
Removing mongo         ... done
Removing network mongo_default


mongo ja mongo-express sammutettu ja poistettu!

```
Jos näkyy pelkkästään:

```
Stopping mongo-express ... done
Stopping mongo         ... done

```

Skripti ei toimi niinkuin pitää ja silloin pitää erikseen ajaa mongo kansiossa `docker-compose down`

