### PR TITLE
Jest testit toimimaan formikin kanssa

### DIFF
--- a/client/src/tests/RegisterForm.test.js
+++ b/client/src/tests/RegisterForm.test.js
@@ -1,8 +1,9 @@
 import React from 'react'
+import { act } from 'react-dom/test-utils'
 import { render, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import RegisterForm from '../components/RegisterForm'
-test('<RegisterForm /> register form makes new user onSubmit', () => {
+test('<RegisterForm /> register form makes new user onSubmit', async () => {
   //const registerUser = jest.fn()
   const component = render(
     <RegisterForm />
@@ -13,9 +14,12 @@ test('<RegisterForm /> register form makes new user onSubmit', () => {
   const passwordInput = component.container.querySelector('input[name="password"]')
   const form = component.container.querySelector('form')
 
-  fireEvent.change(usernameInput, { target: { value:'Myname' } })
-  fireEvent.change(passwordInput, { target: { value:'myPassword' } })
-  fireEvent.submit(form)
+  await act( async() => {
+    fireEvent.change(usernameInput, { target: { value:'Myname' } })
+    fireEvent.change(passwordInput, { target: { value:'myPassword' } })
+    fireEvent.submit(form)
+  })
+
 //expect(registerUser.mock.calls.username).toBe('Myname')
 //expect(registerUser.mock.calls.password).toBe('myPassword')
 } )


### PR DESCRIPTION
Sain nyt vihdoin muokattua tuon RegisterForm testiä siten, että ei enää tule sitä formik herjaa. En edelleenkään ihan hahmota, mikä logiikka siinä on taustalla, mutta siis näköjään formikin kanssa koko testi pitää tehdä asynkronisena (async) ja testin kaikki fireEventit pitää olla awaitin ja actin sisällä erikseen asynkronisina funktioina... Selkeästi selitetty, mutta siis tarkoittaa sitä, että formikia käyttävien testien rakenne pitää ilmeisesti olla seuraava

```
test('testin nimi', async () => {
  [ ... ]

  await act( async() => {
    fireEvent.change/submit/tms ...
    fireEvent.change/submit/tms ...
  })

expect(...).toBe(...)
} )
```