### PR TITLE
Ohjeiden järjestaminen

### DIFF
--- a/client/src/components/InstructionForm.js
+++ b/client/src/components/InstructionForm.js
@@ -12,6 +12,7 @@ const InstructionForm = ({ product }) => {
     productService.createInstruction(product.id, instruction)
       .then(i => {
         product.instructions.push(i)
+        product.instructions.sort((a,b) => b.score - a.score)
         updateProduct(product)
         setNotification('Ohje lisätty!', 'success')
       }).catch(e => {

--- a/server/controllers/products.js
+++ b/server/controllers/products.js
@@ -9,7 +9,10 @@ productRouter.get('/', async (req, res) => {
     score: 1,
     information: 1
   })
+
+  products.forEach(p => p.instructions.sort((a,b) => b.score - a.score))
   res.json(products.map((product) => product.toJSON()))
+
 })
 
 productRouter.get('/user', async (req, res) => {

--- a/server/controllers/products.js
+++ b/server/controllers/products.js
@@ -20,10 +20,20 @@ productRouter.get('/user', async (req, res) => {
   res.json(favorites.map((product) => product.toJSON()))
 })
 
-productRouter.get('/:id', (req, res) => {
-  Product.findById(req.params.id).then((product) => {
+productRouter.get('/:id', async (req, res) => {
+  try {
+    const product = await Product.findById(req.params.id).populate('instructions', {
+      score: 1,
+      information: 1
+    })
+    product.instructions.sort((a,b) => b.score - a.score)
     res.json(product)
-  }).catch(res.status(401).json({ error: 'No product' }))
+    
+  } catch (error) {
+    return res.status(400).json({ error: 'no product found' })  
+  }
+  
+  
 })
 
 const getTokenFrom = (req) => {

--- a/server/tests/kierratysavustin_api.test.js
+++ b/server/tests/kierratysavustin_api.test.js
@@ -66,9 +66,13 @@ test('all products are returned', async () => {
 })
 
 test('all products instructions are ordered by score', async () => {
-  const user = {
-    username: 'root',
-    password: 'salasana',
+  const passwordHash = await bcrypt.hash('testing', 10)
+  let user = new User({ username: 'testing', passwordHash })
+
+  await user.save()
+  user = {
+    username: 'testing',
+    password: 'testing',
   }
 
   token = await getToken(user)


### PR DESCRIPTION
Ohjeet järjestetään nyt backendissä scoren mukaan. Huomasin tässä yhteydessä, että backendin yhden tuotteen hakemiseen liittyvä kysely oli rikki ja palautti aina 'no product' virheilmoituksen, joten korjasin sen samalla. Sitä ei nyt itse asiassa käytetä näköjään missään, vaan esim. testeissä haetaan aina kaikki tuotteet ja valitaan niistä yksi, eli tuosta voisi miettiä olisko syytä tehdä jotain refaktorointia, jos sillä saa jotain yksinkertaistettua. Joka tapauksessa siis nyt backend palauttaa tuotteeseen liittyvät ohjeet järjestyksessä riippumatta siitä, haetaanko yksi vai kaikki tuotteet.

Tein lisäksi nyt ohjeiden järjestämisen frontin puolelle ohjeen lisäyksen yhteyteen, koska muuten uudet ohjeet menevät aina listan loppuun, mitä ei pitäisi käydä, koska uuden score on aina 0, joten sen pitää olla ylempänä kuin sellaiset, joiden score on miinuksella. Frontin osalta tuon ominaisuuden osalta pitää tehdä vielä täydennyksiä (järjestyksen muutokset like/dislikejen päivittyessä ja testit) sitten, kun like/dislike toiminto on toteutettuna frontin puolella.

Huomasin myös tässä yhteydessä kun kirjottelin testejä, että backendin kierratysavustin_api.test.js tiedosto alkaa olla melkoisen pitkä, joten sen hajottamisen pienempiin tiedostoihin voisi ottaa mukaan vikan sprintin siivoustoimiin.