### PR TITLE
Korjattu ohjeiden järjestäminen frontissa

### DIFF
--- a/client/src/components/Product.js
+++ b/client/src/components/Product.js
@@ -28,7 +28,7 @@ const Product = ({ product }) => {
   useEffect(() => {
     clearNotification()
   }, [])
-  console.log('tuote',product)
+  //console.log('tuote',product)
 
   if (!product) return null
 

--- a/client/src/components/VoteForm.js
+++ b/client/src/components/VoteForm.js
@@ -32,7 +32,6 @@ const VoteForm = ( { instruction, user, product }  ) => {
       instruction.score += -1
       setLikes(newArray)
       productService.removeLike(instruction.id).then(instruction => setVotes(instruction.score))
-      product.instructions.sort((a,b) => b.score - a.score)
     } else {
       setLike(true)
       productService.addLike(instruction.id).then(setLikes(likes.concat(instruction.id))).then(instruction => setVotes(instruction.score))
@@ -47,10 +46,11 @@ const VoteForm = ( { instruction, user, product }  ) => {
         }
         setDislikes(newArray)
         setDislike(false)
-        product.instructions.sort((a,b) => b.score - a.score)
       }
 
     }
+
+    product.instructions.sort((a,b) => b.score - a.score)
 
   }
 
@@ -68,7 +68,6 @@ const VoteForm = ( { instruction, user, product }  ) => {
 
       setDislikes(newArray)
       productService.removeDislike(instruction.id).then(instruction => setVotes(instruction.score))
-      product.instructions.sort((a,b) => b.score - a.score)
 
     } else {
       setDislike(true)
@@ -87,8 +86,9 @@ const VoteForm = ( { instruction, user, product }  ) => {
       }
 
       productService.addDislike(instruction.id).then(setDislikes(dislikes.concat(instruction.id))).then(instruction => setVotes(instruction.score))
-      product.instructions.sort((a,b) => b.score - a.score)
     }
+
+    product.instructions.sort((a,b) => b.score - a.score)
   }
   return (
     <div>


### PR DESCRIPTION
Vilkaisin nyt vielä hieman tuota ohjeiden järjestämistä, mikä ei siinä asiakastapaamisessa toiminut ja ainoa mitä keksin oli, että sen sijaan, että järjestäminen tapahtuu erikseen jokaisessa if/else haarassa, niin nyt tässä se tehdään aina handleLike ja handleDislike lopuksi, jolloin se ei ainakaan jää suorittamatta. Ainakin omissa testeissä nyt ohjeiden järjestys muuttuu juuri niinkuin pitää (tosin niin se muuttui aikaisemminkin, eli täytyy vielä tsekata tuon toimivuus stagin serverillä).