### PR TITLE
Back end testien refaktorointia

### DIFF
--- a/server/tests/kierratysavustin_api.test.js
+++ b/server/tests/kierratysavustin_api.test.js
@@ -157,14 +157,9 @@ describe('One account already in database', () => {
         name: 'makkarakastike',
       }
 
-      await api
-        .post('/api/products')
-        .set('Authorization', `bearer ${token}`)
-        .send(newProduct)
-        .expect(201)
-        .expect('Content-Type', /application\/json/)
-      
-      const allProducts = await api.get('/api/products')
+      await helper.addNewProduct(newProduct, token)
+ 
+      const allProducts = await helper.getProducts()
       expect(allProducts.body).toHaveLength(helper.productsData.length + 1)
     })
 
@@ -172,7 +167,7 @@ describe('One account already in database', () => {
       const newInstruction = {
         information: 'maito',
       }
-      const allProducts = await api.get('/api/products')
+      const allProducts = await helper.getProducts()
       const product = allProducts.body[0]
       const result = await helper.addInstruction(product, token, newInstruction)
       expect(result.body.information).toBe(newInstruction.information)
@@ -180,8 +175,6 @@ describe('One account already in database', () => {
     })
 
     test('user can add products to favourites', async () => {
-
-      //const allProducts = await api.get('/api/products')
       const allProducts = await helper.getProducts()
       const product = allProducts.body[0]
 
@@ -192,8 +185,7 @@ describe('One account already in database', () => {
     })
 
     test('user can remove products from favorites', async () => {
-
-      const allProducts = await api.get('/api/products')
+      const allProducts = await helper.getProducts()
       const product = allProducts.body[0]
 
       // Lisätään
@@ -210,8 +202,7 @@ describe('One account already in database', () => {
     })
 
     test('user can like an instruction', async () => {
-
-      const allProducts = await api.get('/api/products')
+      const allProducts = await helper.getProducts()
       const instruction = allProducts.body[0].instructions[0]
 
       const result = await helper.likeInstruction(instruction.id, token)
@@ -235,8 +226,7 @@ describe('One account already in database', () => {
     })
 
     test('user can remove a like from an instruction', async () => {
-
-      const allProducts = await api.get('/api/products')
+      const allProducts = await helper.getProducts()
       const instruction = allProducts.body[0].instructions[0]
 
       //lisätään
@@ -256,8 +246,7 @@ describe('One account already in database', () => {
     })
 
     test('user can remove a dislike from an instruction', async () => {
-
-      const allProducts = await api.get('/api/products')
+      const allProducts = await helper.getProducts()
       const instruction = allProducts.body[0].instructions[0]
 
       //lisätään
@@ -277,8 +266,7 @@ describe('One account already in database', () => {
     })
 
     test('user can like an instruction after it has been disliked', async () => {
-
-      const allProducts = await api.get('/api/products')
+      const allProducts = await helper.getProducts()
       const instruction = allProducts.body[0].instructions[0]
 
       //eitykätään
@@ -299,8 +287,7 @@ describe('One account already in database', () => {
     })
 
     test('user can dislike an instruction after it has been liked', async () => {
-
-      const allProducts = await api.get('/api/products')
+      const allProducts = await helper.getProducts()
       const instruction = allProducts.body[0].instructions[0]
 
       //tykätään

--- a/server/tests/test_helper.js
+++ b/server/tests/test_helper.js
@@ -1,0 +1,70 @@
+const Product = require('../models/product')
+//const Instruction = require('../models/instruction')
+const User = require('../models/user')
+const app = require('../app')
+const supertest = require('supertest')
+const api = supertest(app)
+
+const productsData = [
+  { name: 'Mustamakkarakastike pullo' },
+  {
+    name: 'Sanomalehti',
+  },
+]
+
+
+const usersInDb = async () => {
+  const users = await User.find({})
+  return users.map((u) => u.toJSON())
+}
+
+const productsInDb = async () => {
+  const products = await Product.find({})
+  return products.map(p => p.toJSON())
+}
+
+const getToken = async (props) => {
+  const login = await api
+    .post('/api/login')
+    .send(props)
+    
+  return login.body.token
+}
+
+const getProducts = async () => {
+  const products = await api.get('/api/products')
+  return products
+}
+
+const addInstruction = async (product, token, instruction) => {
+  await api.
+    post(`/api/products/${product.id}/instructions`)
+    .set('Authorization', 'bearer ' + token)
+    .set('Content-Type',  'application/json')
+    .send(instruction)
+    .expect(201)
+    .expect('Content-Type', /application\/json/)
+}
+
+const likeInstruction = async (instructionId, token) => {
+  await api
+    .post('/api/users/likes/' + instructionId)
+    .set('Authorization', `bearer ${token}`)
+    .set('Content-Type',  'application/json')
+    .expect(201)
+    .expect('Content-Type', /application\/json/)
+}
+
+const disLikeInstruction = async (instructionId, token) => {
+  await api
+    .post('/api/users/dislikes/' + instructionId)
+    .set('Authorization', `bearer ${token}`)
+    .set('Content-Type',  'application/json')
+    .expect(201)
+    .expect('Content-Type', /application\/json/)
+}
+
+module.exports = {
+  usersInDb, getToken, productsData, productsInDb, getProducts
+  , addInstruction, likeInstruction, disLikeInstruction
+}

--- a/server/tests/test_helper.js
+++ b/server/tests/test_helper.js
@@ -1,4 +1,4 @@
-const Product = require('../models/product')
+//const Product = require('../models/product')
 //const Instruction = require('../models/instruction')
 const User = require('../models/user')
 const app = require('../app')
@@ -18,10 +18,10 @@ const usersInDb = async () => {
   return users.map((u) => u.toJSON())
 }
 
-const productsInDb = async () => {
+/* const productsInDb = async () => {
   const products = await Product.find({})
   return products.map(p => p.toJSON())
-}
+} */
 
 const getToken = async (props) => {
   const login = await api
@@ -36,35 +36,82 @@ const getProducts = async () => {
   return products
 }
 
+const addFavourite = async (productId, token) => {
+  const result = await api
+    .post('/api/users/products/' + productId)
+    .set('Authorization', `bearer ${token}`)
+    .set('Content-Type',  'application/json')
+    .expect(201)
+    .expect('Content-Type', /application\/json/)
+  return result
+}
+
+const removeFavourite = async (productId, token) => {
+  const result = await api
+    .put('/api/users/products/' + productId)
+    .set('Authorization', `bearer ${token}`)
+    .set('Content-Type',  'application/json')
+    .expect(201)
+    .expect('Content-Type', /application\/json/)
+  return result
+}
+
+
 const addInstruction = async (product, token, instruction) => {
-  await api.
+  const result = await api.
     post(`/api/products/${product.id}/instructions`)
     .set('Authorization', 'bearer ' + token)
     .set('Content-Type',  'application/json')
     .send(instruction)
     .expect(201)
     .expect('Content-Type', /application\/json/)
+  return result
 }
 
+
 const likeInstruction = async (instructionId, token) => {
-  await api
+  const result = await api
     .post('/api/users/likes/' + instructionId)
     .set('Authorization', `bearer ${token}`)
     .set('Content-Type',  'application/json')
     .expect(201)
     .expect('Content-Type', /application\/json/)
+  return result
+}
+
+const unLikeInstruction = async (instructionId, token) => {
+  const result = await api
+    .put('/api/users/likes/' + instructionId)
+    .set('Authorization', `bearer ${token}`)
+    .set('Content-Type',  'application/json')
+    .expect(201)
+    .expect('Content-Type', /application\/json/)
+  return result
 }
 
 const disLikeInstruction = async (instructionId, token) => {
-  await api
+  const result = await api
     .post('/api/users/dislikes/' + instructionId)
     .set('Authorization', `bearer ${token}`)
     .set('Content-Type',  'application/json')
     .expect(201)
     .expect('Content-Type', /application\/json/)
+  return result
+}
+
+const unDisLikeInstruction = async (instructionId, token) => {
+  const result = await api
+    .put('/api/users/dislikes/' + instructionId)
+    .set('Authorization', `bearer ${token}`)
+    .set('Content-Type',  'application/json')
+    .expect(201)
+    .expect('Content-Type', /application\/json/)
+  return result
 }
 
 module.exports = {
-  usersInDb, getToken, productsData, productsInDb, getProducts
+  usersInDb, getToken, productsData, getProducts
   , addInstruction, likeInstruction, disLikeInstruction
+  , unLikeInstruction, unDisLikeInstruction, addFavourite
+  , removeFavourite
 }

--- a/server/tests/test_helper.js
+++ b/server/tests/test_helper.js
@@ -1,5 +1,3 @@
-//const Product = require('../models/product')
-//const Instruction = require('../models/instruction')
 const User = require('../models/user')
 const app = require('../app')
 const supertest = require('supertest')
@@ -18,10 +16,6 @@ const usersInDb = async () => {
   return users.map((u) => u.toJSON())
 }
 
-/* const productsInDb = async () => {
-  const products = await Product.find({})
-  return products.map(p => p.toJSON())
-} */
 
 const getToken = async (props) => {
   const login = await api
@@ -34,6 +28,16 @@ const getToken = async (props) => {
 const getProducts = async () => {
   const products = await api.get('/api/products')
   return products
+}
+
+const addNewProduct = async (newProduct, token) => {
+  const result = await api
+    .post('/api/products')
+    .set('Authorization', `bearer ${token}`)
+    .send(newProduct)
+    .expect(201)
+    .expect('Content-Type', /application\/json/)
+  return result
 }
 
 const addFavourite = async (productId, token) => {
@@ -113,5 +117,5 @@ module.exports = {
   usersInDb, getToken, productsData, getProducts
   , addInstruction, likeInstruction, disLikeInstruction
   , unLikeInstruction, unDisLikeInstruction, addFavourite
-  , removeFavourite
+  , removeFavourite, addNewProduct
 }


### PR DESCRIPTION
Lisäsin back end testeihin useita apufunktioita, joiden avulla testit muuttuu hieman helpommin hahmotettavaan muotoon ja vähemmän toisteista koodia. Testit edelleen yhdessä tiedostossa, mutta katsoin fullstack materiaaleista ja sielläkin api testit oli samalla tavalla yhdessä tiedostossa, joten ehkä ei ole niin suuri ongelma, vaikka testeissä onkin yli 300 riviä koodia samassa tiedostossa.